### PR TITLE
Implemented with mapAccumL

### DIFF
--- a/haskell/AccumL.hs
+++ b/haskell/AccumL.hs
@@ -1,0 +1,44 @@
+module AccumL where
+
+import Data.List
+
+data Section a = Section
+  { title      :: String
+  , reset      :: Bool
+  , lessons    :: [(String, a)]
+  , annotation :: a
+  } deriving Show
+
+annotate :: [Section a] -> [Section Int]
+annotate = snd . mapAccumL annotateSection (1, 1)
+
+annotateSection :: (Int, Int) -> Section a -> ((Int, Int), Section Int)
+annotateSection (sectionCounter, lessonCounter) section
+  = ((sectionCounter + 1, lessonCounter' + count), section')
+  where
+    count          = length $ lessons section
+    lessonCounter' = if reset section then 1 else lessonCounter
+    section'       = section { annotation = sectionCounter, lessons = lessons' }
+    lessons'       = zipWith (\(l, _) idx -> (l, idx)) (lessons section) $ enumFrom lessonCounter'
+
+sample :: [Section ()]
+sample =
+  [ Section
+    { title = "Getting started"
+    , reset = False
+    , lessons = [("Welcome", ()), ("Installation", ())]
+    , annotation = ()
+    }
+  , Section
+    { title = "Basic operator"
+    , reset = False
+    , lessons = [("Addition / Subtraction", ()), ("Multiplication / Division", ())]
+    , annotation = ()
+    }
+  , Section
+    { title = "Advanced topics"
+    , reset = True
+    , lessons = [("Mutability", ()), ("Immutability", ())]
+    , annotation = ()
+    }
+  ]


### PR DESCRIPTION
In contrast with fold or primitive recursion, mapAccumL guarantees the annotated sections will be as many as the input.

<!--

Thanks for showing interest in submitting a solution!

New solutions to the problem are welcome. In order to contribute:

* Make sure there are no entries for your programming language of choice
* If there are existing entries, make sure your proposed solution is considerably distinct

For example, avoid new entries that are small variations of existing solutions.
Solutions that use different approaches, such as mutability vs immutability,
single-pass vs chunking, etc are all welcome though.

-->
